### PR TITLE
Fixed: calling add_image_annotation results in infinite recursion

### DIFF
--- a/implementations/manifest-factory/factory.py
+++ b/implementations/manifest-factory/factory.py
@@ -838,7 +838,7 @@ class Canvas(ContentResource):
 
 	def add_image_annotation(self, imgid, iiif=True):
 		self.maybe_warn("add_image_annotation is deprecated; use set_image_annotation() please")
-		self.add_image_annotation(imgid, iiif)
+		self.set_image_annotation(imgid, iiif)
 
 	def set_image_annotation(self, imgid, iiif=True):
 		# Make simple image annotation


### PR DESCRIPTION
I discovered this while using `build-from-directory.py`, which calls `add_image_annotation`.